### PR TITLE
Potential CSS Conflict Fix

### DIFF
--- a/src/FaceLivenessAmplify.scss
+++ b/src/FaceLivenessAmplify.scss
@@ -1,0 +1,1 @@
+@import "~@aws-amplify/ui-angular/theme.css";

--- a/src/FaceLivenessReactWrapperComponent.tsx
+++ b/src/FaceLivenessReactWrapperComponent.tsx
@@ -24,7 +24,7 @@ const containerElementName = 'faceLivenessReactContainer';
     selector: 'app-faceliveness-react-wrapper',
     template: `<span #${containerElementName}></span>`,
     // styleUrls: [''],
-    encapsulation: ViewEncapsulation.None,
+    encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class FaceLivenessReactWrapperComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {
     @ViewChild(containerElementName, { static: true }) containerRef!: ElementRef;

--- a/src/FaceLivenessReactWrapperComponent.tsx
+++ b/src/FaceLivenessReactWrapperComponent.tsx
@@ -23,7 +23,7 @@ const containerElementName = 'faceLivenessReactContainer';
 @Component({
     selector: 'app-faceliveness-react-wrapper',
     template: `<span #${containerElementName}></span>`,
-    // styleUrls: [''],
+    styleUrls: ['./FaceLivenessAmplify.scss'],
     encapsulation: ViewEncapsulation.ShadowDom,
 })
 export class FaceLivenessReactWrapperComponent implements OnInit, OnChanges, OnDestroy, AfterViewInit {


### PR DESCRIPTION
*Issue*: I faced an issue where my local Angular App had CSS that was conflicting with the Amplify's CSS for the AWS Rekognition Face Liveness.

*Description of changes:*
To resolve this, I needed to isolate the FaceLiveness DOM to prevent my Angular App's CSS to be reflected in the app. In order to achieve that, we can make use of the View Encapsulation property available on our React Component and import the CSS directly into the Wrapper Component.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
